### PR TITLE
Add MySQL replication topology Grafana dashboard and format Prometheus info as tables

### DIFF
--- a/monitor/prometheus_info/mysql_replication_topology.json
+++ b/monitor/prometheus_info/mysql_replication_topology.json
@@ -1,0 +1,298 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": false,
+        "iconColor": "#e0752d",
+        "limit": 100,
+        "name": "PMM Annotations",
+        "showIn": 0,
+        "tags": [
+          "pmm_annotation"
+        ],
+        "type": "tags"
+      },
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "#6ed0e0",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "tags": [],
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1770000000000,
+  "links": [
+    {
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "MySQL"
+      ],
+      "targetBlank": false,
+      "title": "MySQL",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "columns": [],
+      "datasource": "Prometheus",
+      "description": "Overview of MySQL replication topology using slave status metrics. Use the instance filter to focus on specific hosts.",
+      "fontSize": "100%",
+      "hideTimeOverride": false,
+      "id": 1,
+      "interval": "$interval",
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "Replication",
+          "type": "absolute",
+          "url": "https://dev.mysql.com/doc/refman/5.7/en/replication.html"
+        }
+      ],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias": "Instance",
+          "colorMode": null,
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "pattern": "instance",
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Master Server ID",
+          "colorMode": null,
+          "decimals": 0,
+          "pattern": "Value #A",
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Master Port",
+          "colorMode": null,
+          "decimals": 0,
+          "pattern": "Value #B",
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Slave IO Running",
+          "colorMode": "cell",
+          "colors": [
+            "rgba(161, 18, 18, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(36, 112, 33, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "Value #C",
+          "thresholds": "0.5,0.9",
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Slave SQL Running",
+          "colorMode": "cell",
+          "colors": [
+            "rgba(161, 18, 18, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(36, 112, 33, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "Value #D",
+          "thresholds": "0.5,0.9",
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Seconds Behind Master",
+          "colorMode": null,
+          "decimals": 0,
+          "pattern": "Value #E",
+          "type": "number",
+          "unit": "s"
+        },
+        {
+          "alias": "Time",
+          "pattern": "Time",
+          "type": "hidden"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "mysql_slave_status_master_server_id{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "mysql_slave_status_master_port{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "mysql_slave_status_slave_io_running{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "expr": "mysql_slave_status_slave_sql_running{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "expr": "mysql_slave_status_seconds_behind_master{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "E"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "MySQL Replication Topology",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "MySQL",
+    "Replication"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(mysql_slave_status_slave_io_running, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "auto",
+          "value": "$__auto_interval"
+        },
+        "hide": 2,
+        "label": "Interval",
+        "name": "interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          }
+        ],
+        "query": "1m,5m,15m,1h",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "MySQL Replication Topology",
+  "uid": "mysql-replication-topology",
+  "version": 1
+}

--- a/monitor/prometheus_info/prometheus_info
+++ b/monitor/prometheus_info/prometheus_info
@@ -1,19 +1,31 @@
-untime Information
-Uptime	2025-09-12 08:52:13.272484721 +0000 UTC
-Working Directory	/opt
-Configuration reload	Successful
-Last successful configuration reload	2025-09-12 08:57:50 +0000 UTC
-Head chunks	22021949
-Head time series	1587133
-WAL corruptions	0
-Goroutines	2272
-GOMAXPROCS	32
-GOGC	
-Build Information
-Version	2.3.2
-Revision	71af5e29e815795e9dd14742ee7725682fa14b7b
-Branch	v2.3.2
-BuildUser	Jenkins
-BuildDate	20200618-15:08:55OURCE
-GoVersion	go1.10.1
-Grafana 5.4.5
+# Prometheus Runtime Information
+
+| Item | Value |
+| --- | --- |
+| Uptime | 2025-09-12 08:52:13.272484721 +0000 UTC |
+| Working Directory | /opt |
+| Configuration reload | Successful |
+| Last successful configuration reload | 2025-09-12 08:57:50 +0000 UTC |
+| Head chunks | 22021949 |
+| Head time series | 1587133 |
+| WAL corruptions | 0 |
+| Goroutines | 2272 |
+| GOMAXPROCS | 32 |
+| GOGC |  |
+
+# Prometheus Build Information
+
+| Item | Value |
+| --- | --- |
+| Version | 2.3.2 |
+| Revision | 71af5e29e815795e9dd14742ee7725682fa14b7b |
+| Branch | v2.3.2 |
+| Build user | Jenkins |
+| Build date | 20200618-15:08:55 |
+| Go version | go1.10.1 |
+
+# Grafana
+
+| Item | Value |
+| --- | --- |
+| Version | 5.4.5 |


### PR DESCRIPTION
### Motivation
- Provide a Grafana dashboard to visualize MySQL replication topology and key slave status metrics for easier operational visibility.
- Improve readability of Prometheus info output by converting free-form runtime/build lines into structured Markdown tables and correcting field labels.

### Description
- Add `monitor/prometheus_info/mysql_replication_topology.json`, a Grafana dashboard JSON that presents a table panel with metrics `mysql_slave_status_master_server_id`, `mysql_slave_status_master_port`, `mysql_slave_status_slave_io_running`, `mysql_slave_status_slave_sql_running`, and `mysql_slave_status_seconds_behind_master`, and includes `instance` and `interval` templating variables and UID `mysql-replication-topology`.
- Update `monitor/prometheus_info/prometheus_info` to render Prometheus runtime information, build information, and Grafana version as separate Markdown tables and rename fields like `BuildUser` → `Build user` and `BuildDate` → `Build date`.
- Add descriptive panel links and panel styling/thresholds for `Slave IO Running` and `Slave SQL Running` to surface running status via cell coloring.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f0b2572908328a1dd0bda3eb519c9)