### PR TITLE
feat: add Podman-based poc-db-architect-quickstart lab with Redis scenarios

### DIFF
--- a/poc/poc-db-architect-quickstart/.env.example
+++ b/poc/poc-db-architect-quickstart/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and adjust if needed.
+PODMAN_BIN=podman
+PROJECT_NAME=poc-db-architect-quickstart

--- a/poc/poc-db-architect-quickstart/Makefile
+++ b/poc/poc-db-architect-quickstart/Makefile
@@ -1,0 +1,37 @@
+SHELL := /usr/bin/env bash
+
+SCENARIO ?=
+SCENARIO_DIR := scenarios/$(SCENARIO)
+
+.PHONY: help init up down reset verify logs list
+
+help:
+	@echo "Usage:"
+	@echo "  make init"
+	@echo "  make up SCENARIO=<name>"
+	@echo "  make down SCENARIO=<name>"
+	@echo "  make reset SCENARIO=<name>"
+	@echo "  make verify SCENARIO=<name>"
+	@echo "  make logs SCENARIO=<name>"
+	@echo "  make list"
+
+list:
+	@find scenarios -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort
+
+init:
+	@./bin/init.sh
+
+up:
+	@./bin/up.sh $(SCENARIO)
+
+down:
+	@./bin/down.sh $(SCENARIO)
+
+reset:
+	@./bin/reset.sh $(SCENARIO)
+
+verify:
+	@./bin/doctor.sh $(SCENARIO)
+
+logs:
+	@./bin/logs.sh $(SCENARIO)

--- a/poc/poc-db-architect-quickstart/README.md
+++ b/poc/poc-db-architect-quickstart/README.md
@@ -1,0 +1,131 @@
+# poc-db-architect-quickstart
+
+A macOS-friendly local **database architecture lab** powered by Podman and `podman kube play`.
+
+This repository is scenario-driven so architects can quickly switch between topology patterns.
+
+## Quick Start (5 minutes)
+
+```bash
+# 1) Install podman
+brew install podman
+
+# 2) Init and start VM
+podman machine init
+podman machine start
+
+# 3) Enter project
+cd poc-db-architect-quickstart
+
+# 4) Start first scenario
+make up SCENARIO=redis-standalone
+
+# 5) Verify
+make verify SCENARIO=redis-standalone
+```
+
+## Prerequisites
+
+- macOS host
+- Podman 4+
+- `podman machine` working
+- `make`
+
+## Scenario Catalog
+
+```bash
+make list
+```
+
+Current scenarios:
+
+- `redis-standalone` (single node)
+- `redis-replication` (1 master + 2 replicas)
+- `redis-sentinel` (master/replica + 3 sentinel nodes)
+- `redis-cluster` (6-node Redis cluster)
+
+## Operations Interface
+
+```bash
+make up SCENARIO=<name>
+make down SCENARIO=<name>
+make reset SCENARIO=<name>
+make verify SCENARIO=<name>
+make logs SCENARIO=<name>
+```
+
+## Architecture Diagrams
+
+### redis-standalone
+
+```text
+Client -> 127.0.0.1:6379 -> redis-standalone-1
+```
+
+### redis-replication
+
+```text
+                +----------------------------+
+Client -> 6380  | redis-replication-master-1 |
+                +----------------------------+
+                    |                |
+                 sync to          sync to
+                    v                v
+            +----------------+  +----------------+
+Client->6381| replica-1      |  | replica-2      |<-Client->6382
+            +----------------+  +----------------+
+```
+
+### redis-sentinel
+
+```text
+Data Plane:
+  master(6390) <-> replica(6391)
+Control Plane:
+  sentinel-1(26379)
+  sentinel-2(26380)
+  sentinel-3(26381)
+```
+
+### redis-cluster
+
+```text
+7001 7002 7003 (masters)
+7004 7005 7006 (replicas)
+Hash slots are distributed after cluster bootstrap.
+```
+
+## Login Instructions
+
+See each scenario document:
+
+- `scenarios/redis-standalone/login.md`
+- `scenarios/redis-replication/login.md`
+- `scenarios/redis-sentinel/login.md`
+- `scenarios/redis-cluster/login.md`
+
+## Verify Commands
+
+```bash
+make verify SCENARIO=redis-standalone
+make verify SCENARIO=redis-replication
+make verify SCENARIO=redis-sentinel
+make verify SCENARIO=redis-cluster
+```
+
+## Extending the Lab
+
+To add a new scenario:
+
+1. Create `scenarios/<new-scenario>/kube.yaml`
+2. Add `scenarios/<new-scenario>/verify.sh`
+3. Add `scenarios/<new-scenario>/login.md`
+4. Run using existing Make targets
+
+Suggested future additions:
+
+- `mysql-standalone`
+- `mysql-group-replication`
+- `postgres-ha`
+- `mongo-replica-set`
+- `tidb-local`

--- a/poc/poc-db-architect-quickstart/bin/doctor.sh
+++ b/poc/poc-db-architect-quickstart/bin/doctor.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-}"
+if [[ -z "$SCENARIO" ]]; then
+  echo "Usage: $0 <scenario>"
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scenarios/$SCENARIO/verify.sh"
+
+if [[ ! -x "$VERIFY_SCRIPT" ]]; then
+  echo "[ERROR] verify.sh is missing or not executable for scenario: $SCENARIO"
+  exit 1
+fi
+
+"$VERIFY_SCRIPT"

--- a/poc/poc-db-architect-quickstart/bin/down.sh
+++ b/poc/poc-db-architect-quickstart/bin/down.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-}"
+if [[ -z "$SCENARIO" ]]; then
+  echo "Usage: $0 <scenario>"
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KUBE_FILE="$ROOT_DIR/scenarios/$SCENARIO/kube.yaml"
+PODMAN_BIN="${PODMAN_BIN:-podman}"
+
+if [[ ! -f "$KUBE_FILE" ]]; then
+  echo "[ERROR] Scenario not found: $SCENARIO"
+  exit 1
+fi
+
+"$PODMAN_BIN" kube down "$KUBE_FILE" || true
+echo "[OK] Scenario stopped: $SCENARIO"

--- a/poc/poc-db-architect-quickstart/bin/init.sh
+++ b/poc/poc-db-architect-quickstart/bin/init.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PODMAN_BIN="${PODMAN_BIN:-podman}"
+
+if ! command -v "$PODMAN_BIN" >/dev/null 2>&1; then
+  echo "[ERROR] podman is not installed."
+  echo "Install: brew install podman"
+  exit 1
+fi
+
+if ! "$PODMAN_BIN" machine info >/dev/null 2>&1; then
+  echo "[INFO] Podman machine not initialized. Running: podman machine init"
+  "$PODMAN_BIN" machine init
+fi
+
+if ! "$PODMAN_BIN" info >/dev/null 2>&1; then
+  echo "[INFO] Starting podman machine..."
+  "$PODMAN_BIN" machine start
+fi
+
+echo "[OK] Podman is ready."

--- a/poc/poc-db-architect-quickstart/bin/logs.sh
+++ b/poc/poc-db-architect-quickstart/bin/logs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-}"
+PODMAN_BIN="${PODMAN_BIN:-podman}"
+
+if [[ -z "$SCENARIO" ]]; then
+  "$PODMAN_BIN" pod ps
+  exit 0
+fi
+
+"$PODMAN_BIN" pod logs "$SCENARIO"

--- a/poc/poc-db-architect-quickstart/bin/reset.sh
+++ b/poc/poc-db-architect-quickstart/bin/reset.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-}"
+if [[ -z "$SCENARIO" ]]; then
+  echo "Usage: $0 <scenario>"
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$ROOT_DIR/bin/down.sh" "$SCENARIO"
+
+rm -rf "$ROOT_DIR/volumes/$SCENARIO"
+mkdir -p "$ROOT_DIR/volumes/$SCENARIO"
+
+"$ROOT_DIR/bin/up.sh" "$SCENARIO"
+echo "[OK] Scenario reset: $SCENARIO"

--- a/poc/poc-db-architect-quickstart/bin/up.sh
+++ b/poc/poc-db-architect-quickstart/bin/up.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-}"
+if [[ -z "$SCENARIO" ]]; then
+  echo "Usage: $0 <scenario>"
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCENARIO_DIR="$ROOT_DIR/scenarios/$SCENARIO"
+KUBE_FILE="$SCENARIO_DIR/kube.yaml"
+PODMAN_BIN="${PODMAN_BIN:-podman}"
+
+if [[ ! -f "$KUBE_FILE" ]]; then
+  echo "[ERROR] Scenario not found: $SCENARIO"
+  exit 1
+fi
+
+mkdir -p "$ROOT_DIR/volumes/$SCENARIO"
+
+"$PODMAN_BIN" kube play --replace "$KUBE_FILE"
+
+echo "[OK] Scenario started: $SCENARIO"
+
+if [[ "$SCENARIO" == "redis-cluster" ]]; then
+  echo "[INFO] Initializing redis cluster topology..."
+  sleep 4
+  "$PODMAN_BIN" exec redis-cluster-node-1 redis-cli --cluster create \
+    127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 \
+    127.0.0.1:7004 127.0.0.1:7005 127.0.0.1:7006 \
+    --cluster-replicas 1 --cluster-yes || true
+fi

--- a/poc/poc-db-architect-quickstart/docs/architecture/README.md
+++ b/poc/poc-db-architect-quickstart/docs/architecture/README.md
@@ -1,0 +1,8 @@
+# Architecture Notes
+
+This project is organized by **scenarios** (topology pattern), not by database vendor.
+
+- standalone: single node workload
+- replication: primary-replica topology
+- sentinel: HA detection and failover coordination
+- cluster: sharding + replicas

--- a/poc/poc-db-architect-quickstart/docs/login/README.md
+++ b/poc/poc-db-architect-quickstart/docs/login/README.md
@@ -1,0 +1,3 @@
+# Login Guide
+
+Each scenario has its own `login.md` under `scenarios/<name>/login.md`.

--- a/poc/poc-db-architect-quickstart/docs/operations/README.md
+++ b/poc/poc-db-architect-quickstart/docs/operations/README.md
@@ -1,0 +1,10 @@
+# Operations Guide
+
+Common commands:
+
+```bash
+make up SCENARIO=<name>
+make verify SCENARIO=<name>
+make down SCENARIO=<name>
+make reset SCENARIO=<name>
+```

--- a/poc/poc-db-architect-quickstart/scenarios/redis-cluster/kube.yaml
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-cluster/kube.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-cluster
+  labels:
+    app: redis-cluster
+spec:
+  containers:
+    - &redis_node
+      name: redis-cluster-node-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--port", "7001", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7001.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7001
+          hostPort: 7001
+
+    - <<: *redis_node
+      name: redis-cluster-node-2
+      args: ["--port", "7002", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7002.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7002
+          hostPort: 7002
+
+    - <<: *redis_node
+      name: redis-cluster-node-3
+      args: ["--port", "7003", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7003.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7003
+          hostPort: 7003
+
+    - <<: *redis_node
+      name: redis-cluster-node-4
+      args: ["--port", "7004", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7004.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7004
+          hostPort: 7004
+
+    - <<: *redis_node
+      name: redis-cluster-node-5
+      args: ["--port", "7005", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7005.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7005
+          hostPort: 7005
+
+    - <<: *redis_node
+      name: redis-cluster-node-6
+      args: ["--port", "7006", "--cluster-enabled", "yes", "--cluster-config-file", "nodes-7006.conf", "--cluster-node-timeout", "5000", "--appendonly", "yes"]
+      ports:
+        - containerPort: 7006
+          hostPort: 7006

--- a/poc/poc-db-architect-quickstart/scenarios/redis-cluster/login.md
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-cluster/login.md
@@ -1,0 +1,7 @@
+# redis-cluster login
+
+Use any node and enable cluster mode:
+
+```bash
+redis-cli -h 127.0.0.1 -p 7001 -c
+```

--- a/poc/poc-db-architect-quickstart/scenarios/redis-cluster/verify.sh
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-cluster/verify.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[redis-cluster] topology check"
+podman exec redis-cluster-node-1 redis-cli -p 7001 cluster info | rg "cluster_state:ok"
+podman exec redis-cluster-node-1 redis-cli -p 7001 cluster nodes | head -n 6

--- a/poc/poc-db-architect-quickstart/scenarios/redis-replication/kube.yaml
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-replication/kube.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-replication
+  labels:
+    app: redis-replication
+spec:
+  containers:
+    - name: redis-replication-master-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--appendonly", "yes", "--port", "6380"]
+      ports:
+        - containerPort: 6380
+          hostPort: 6380
+      volumeMounts:
+        - name: master-data
+          mountPath: /data
+
+    - name: redis-replication-replica-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--port", "6381", "--replicaof", "127.0.0.1", "6380"]
+      ports:
+        - containerPort: 6381
+          hostPort: 6381
+      volumeMounts:
+        - name: replica1-data
+          mountPath: /data
+
+    - name: redis-replication-replica-2
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--port", "6382", "--replicaof", "127.0.0.1", "6380"]
+      ports:
+        - containerPort: 6382
+          hostPort: 6382
+      volumeMounts:
+        - name: replica2-data
+          mountPath: /data
+
+  volumes:
+    - name: master-data
+      hostPath:
+        path: ./volumes/redis-replication/master
+        type: DirectoryOrCreate
+    - name: replica1-data
+      hostPath:
+        path: ./volumes/redis-replication/replica1
+        type: DirectoryOrCreate
+    - name: replica2-data
+      hostPath:
+        path: ./volumes/redis-replication/replica2
+        type: DirectoryOrCreate

--- a/poc/poc-db-architect-quickstart/scenarios/redis-replication/login.md
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-replication/login.md
@@ -1,0 +1,7 @@
+# redis-replication login
+
+```bash
+redis-cli -h 127.0.0.1 -p 6380   # master
+redis-cli -h 127.0.0.1 -p 6381   # replica-1
+redis-cli -h 127.0.0.1 -p 6382   # replica-2
+```

--- a/poc/poc-db-architect-quickstart/scenarios/redis-replication/verify.sh
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-replication/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[redis-replication] role check"
+podman exec redis-replication-master-1 redis-cli -p 6380 INFO replication | rg "role:master"
+podman exec redis-replication-replica-1 redis-cli -p 6381 INFO replication | rg "role:slave"
+podman exec redis-replication-replica-2 redis-cli -p 6382 INFO replication | rg "role:slave"

--- a/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/kube.yaml
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/kube.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-sentinel
+  labels:
+    app: redis-sentinel
+spec:
+  containers:
+    - name: redis-sentinel-master-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--appendonly", "yes", "--port", "6390"]
+      ports:
+        - containerPort: 6390
+          hostPort: 6390
+
+    - name: redis-sentinel-replica-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--port", "6391", "--replicaof", "127.0.0.1", "6390"]
+      ports:
+        - containerPort: 6391
+          hostPort: 6391
+
+    - name: redis-sentinel-node-1
+      image: docker.io/library/redis:7.2
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          cat >/tmp/sentinel.conf <<CFG
+          port 26379
+          sentinel monitor mymaster 127.0.0.1 6390 2
+          sentinel down-after-milliseconds mymaster 5000
+          sentinel failover-timeout mymaster 10000
+          sentinel parallel-syncs mymaster 1
+          CFG
+          exec redis-sentinel /tmp/sentinel.conf
+      ports:
+        - containerPort: 26379
+          hostPort: 26379
+
+    - name: redis-sentinel-node-2
+      image: docker.io/library/redis:7.2
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          cat >/tmp/sentinel.conf <<CFG
+          port 26380
+          sentinel monitor mymaster 127.0.0.1 6390 2
+          sentinel down-after-milliseconds mymaster 5000
+          sentinel failover-timeout mymaster 10000
+          sentinel parallel-syncs mymaster 1
+          CFG
+          exec redis-sentinel /tmp/sentinel.conf
+      ports:
+        - containerPort: 26380
+          hostPort: 26380
+
+    - name: redis-sentinel-node-3
+      image: docker.io/library/redis:7.2
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          cat >/tmp/sentinel.conf <<CFG
+          port 26381
+          sentinel monitor mymaster 127.0.0.1 6390 2
+          sentinel down-after-milliseconds mymaster 5000
+          sentinel failover-timeout mymaster 10000
+          sentinel parallel-syncs mymaster 1
+          CFG
+          exec redis-sentinel /tmp/sentinel.conf
+      ports:
+        - containerPort: 26381
+          hostPort: 26381

--- a/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/login.md
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/login.md
@@ -1,0 +1,16 @@
+# redis-sentinel login
+
+Redis data nodes:
+
+```bash
+redis-cli -h 127.0.0.1 -p 6390
+redis-cli -h 127.0.0.1 -p 6391
+```
+
+Sentinel nodes:
+
+```bash
+redis-cli -h 127.0.0.1 -p 26379
+redis-cli -h 127.0.0.1 -p 26380
+redis-cli -h 127.0.0.1 -p 26381
+```

--- a/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/verify.sh
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-sentinel/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[redis-sentinel] monitor check"
+podman exec redis-sentinel-node-1 redis-cli -p 26379 SENTINEL masters | rg "mymaster"
+podman exec redis-sentinel-node-2 redis-cli -p 26380 SENTINEL ckquorum mymaster
+podman exec redis-sentinel-node-3 redis-cli -p 26381 SENTINEL ckquorum mymaster

--- a/poc/poc-db-architect-quickstart/scenarios/redis-standalone/kube.yaml
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-standalone/kube.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-standalone
+  labels:
+    app: redis-standalone
+spec:
+  containers:
+    - name: redis-standalone-1
+      image: docker.io/library/redis:7.2
+      command: ["redis-server"]
+      args: ["--appendonly", "yes", "--port", "6379"]
+      ports:
+        - containerPort: 6379
+          hostPort: 6379
+      volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumes:
+    - name: redis-data
+      hostPath:
+        path: ./volumes/redis-standalone
+        type: DirectoryOrCreate

--- a/poc/poc-db-architect-quickstart/scenarios/redis-standalone/login.md
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-standalone/login.md
@@ -1,0 +1,11 @@
+# redis-standalone login
+
+```bash
+redis-cli -h 127.0.0.1 -p 6379
+```
+
+Inside Podman container:
+
+```bash
+podman exec -it redis-standalone-1 redis-cli -p 6379
+```

--- a/poc/poc-db-architect-quickstart/scenarios/redis-standalone/verify.sh
+++ b/poc/poc-db-architect-quickstart/scenarios/redis-standalone/verify.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[redis-standalone] ping check"
+podman exec redis-standalone-1 redis-cli -p 6379 PING


### PR DESCRIPTION
### Motivation

- Provide a macOS-friendly, Podman-powered local database architecture lab that is scenario-driven for quick PoC, learning, and experiments.
- Favor topology/scenario patterns (standalone, replication, sentinel, cluster) so architects can swap topologies without being database-product locked.
- Make lifecycle operations simple and reproducible using `podman kube play` and a small Makefile + `bin/` utility scripts.

### Description

- Add a new project skeleton `poc/poc-db-architect-quickstart` with `.env.example`, `Makefile`, `README.md`, `docs/`, `bin/` scripts, `scenarios/` and `volumes/` per the requested structure.
- Implement lifecycle tooling in `Makefile` and `bin/`: `init.sh` (validate/init `podman machine`), `up.sh` (runs `podman kube play` and auto-bootstraps `redis-cluster`), `down.sh` (runs `podman kube down`), `reset.sh` (remove/recreate scenario volumes and restart), `doctor.sh` (invokes scenario `verify.sh`), and `logs.sh` (view pods).
- Add four Redis scenario folders each containing `kube.yaml` (Podman Kubernetes manifest), `login.md` (how to connect), and `verify.sh` (validation commands), with deterministic ports and container naming conventions: `redis-standalone` (6379), `redis-replication` (6380-6382), `redis-sentinel` (6390/6391 + 26379-26381), `redis-cluster` (7001-7006).
- Provide user-facing docs and quick start in `README.md` including prerequisites, 5-minute quick start, architecture diagrams, login instructions, verify commands, and extension guidance.

### Testing

- Performed a shell syntax check with `bash -n bin/*.sh scenarios/*/verify.sh` which succeeded for all scripts.
- Listed scenarios via `make list` which returned the four expected scenarios: `redis-cluster`, `redis-replication`, `redis-sentinel`, and `redis-standalone`.
- Verified Make interface help with `make help` which printed the usage targets successfully.
- Validated repository file layout using `find` to ensure all scenario artifacts and `bin/` scripts were created as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8009082883288d9035635979b3c9)